### PR TITLE
linkCheck_NL

### DIFF
--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -53,7 +53,7 @@ markup:
 outputs:
   section:
    - HTML
-   #- print
+   - print
    - RSS
 
 # hugo module configuration

--- a/config/_default/hugo.yml
+++ b/config/_default/hugo.yml
@@ -53,7 +53,7 @@ markup:
 outputs:
   section:
    - HTML
-   - print
+   #- print
    - RSS
 
 # hugo module configuration

--- a/content/nl/docs/acties/_index.md
+++ b/content/nl/docs/acties/_index.md
@@ -30,10 +30,10 @@ Afhankelijk van het type dier, kun je tot 16 verschillende acties uitvoeren voor
    <area shape="rect" coords="175,225,230,280" alt="Animal loss" title="Registreer een verlies van een dier&#10;Muisklik: open documentatie" href="/nl/docs/acties/animal-loss/">
    <area shape="rect" coords="3,280,60,337" alt="Dier verloren" title="Wijs een transponder toe aan een dier&#10;Muisklik: open documentatie" href="/nl/docs/acties/link-transponder/">
    <area shape="rect" coords="55,280,120,337" alt="Transponder afnemen" title="Verwijder de transponderkoppeling van een dier&#10;Muisklik: open documentatie" href="/nl/docs/acties/unlink-transponder/">
-   <area shape="rect" coords="120,280,175,337" alt="Link dier ID manueel" title="Wijs een nationaal dier-ID toe aan een dier dat geen nationaal dier-ID heeft&#10;Muisklik: open documentatie" href="/nl/docs/acties/link-animal-id/#link-dier-id">
-   <area shape="rect" coords="175,280,230,337" alt="Link dier ID with scan" title="Wijs een nationaal dier-ID toe aan een dier dat geen nationaal dier-ID heeft&#10;Muisklik: open documentatie" href="/nl/docs/acties/link-animal-id/#link-animal-id-with-electronic-ear-tag-scan">
+   <area shape="rect" coords="120,280,175,337" alt="Link dier ID manueel" title="Wijs een nationaal dier-ID toe aan een dier dat geen nationaal dier-ID heeft&#10;Muisklik: open documentatie" href="/nl/docs/acties/koppel-dier-id/#link-dier-id">
+   <area shape="rect" coords="175,280,230,337" alt="Link dier ID with scan" title="Wijs een nationaal dier-ID toe aan een dier dat geen nationaal dier-ID heeft&#10;Muisklik: open documentatie" href="/nl/docs/acties/koppel-dier-id/#link-dier-id-aan-elektronische-oormerkscan">
 
-<area shape="rect" coords="100,340,140,375" alt="Instellingen" title="Roep de instellingen op&#10;Muisklik: naar de documentatie" href="/nl/docs/acties/settings/#menuonderdelen">
+<area shape="rect" coords="100,340,140,375" alt="Instellingen" title="Roep de instellingen op&#10;Muisklik: naar de documentatie" href="/nl/docs/acties/instellingen/">
 
 </map>
 

--- a/content/nl/docs/acties/action-setting.md
+++ b/content/nl/docs/acties/action-setting.md
@@ -38,6 +38,6 @@ In dit instellingenmenu stel je de &nbsp;<img src="/icons/actions/action-chain.s
 
 3. Er opent een submenu. Gebruik de pijltoetsen △ ▽ om het menu-item &nbsp;<img src="/icons/actions/action-chain.svg" width="35" align="bottom" alt="Keten van acties" />&nbsp; `Opeenvolgende acties` te selecteren en bevestig met `OK`.
 
-4. Verdere instructies zijn te vinden [hier](/nl/docs/chain-of-actions/#set-chain-of-actions).
+4. Verdere instructies zijn te vinden [hier](/nl/docs/chain-of-actions/#keten-van-acties).
 
     ![VitalControl: Menu Acties Vervolgacties](../images/chainofactions.png "Opeenvolgende acties")

--- a/content/nl/docs/acties/rating.md
+++ b/content/nl/docs/acties/rating.md
@@ -60,5 +60,5 @@ Als u geen selectie maakt met de pijltoetsen ◁ ▷ maar direct opslaat met de 
 {{< /tabpane >}}
 
 {{% alert title="Hint" %}}
-Als deze actie niet beschikbaar is, is de actie waarschijnlijk gedeactiveerd! Activeer de actie in het [actie-instellingen](/nl/docs/acties/settings/#menuonderdelen) menu. Als alternatief zal het resetten van alle acties die actie weer naar voren brengen.
+Als deze actie niet beschikbaar is, is de actie waarschijnlijk gedeactiveerd! Activeer de actie in het [actie-instellingen](/nl/docs/acties/instellingen/) menu. Als alternatief zal het resetten van alle acties die actie weer naar voren brengen.
 {{% /alert %}}

--- a/content/nl/docs/acties/temperature.md
+++ b/content/nl/docs/acties/temperature.md
@@ -15,11 +15,11 @@ translationKey: actions/temperature
 
 Gebruik de temperatuuractie om de temperatuur van uw dieren te meten. Breng de meettip rectaal in tot de gespecificeerde meetdiepte (voor grote dieren de volledige lengte tot aan de verdikking, voor kleine herkauwers ongeveer 6 cm of 2/3 van de meettip). Het meetproces verloopt automatisch. Zodra het meetproces is voltooid, toont het apparaat de gemeten temperatuur. De kleurcodering geeft aan of de temperatuur zich in het groene, gele of rode bereik bevindt. U heeft een aantal opties tijdens de campagne Temperatuur meten:
 
-- [Sla het resultaat op](#save-result) om de meting dierspecifiek te documenteren
+- [Sla het resultaat op](#resultaat-opslaan) om de meting dierspecifiek te documenteren
 - Plaats het dier op de [Kijklijst](#toevoegen-aan-watchlist). Dit maakt het gemakkelijker voor u om de herhalingen te controleren, aangezien u deze dieren kunt oproepen met behulp van de 'observatielijst' en zo de opvallende dieren gemakkelijker kunt vinden.
-- Zet de [Verlichting van de Meetlocatie](#lighting-of-the-measurement-location-on-and-off) aan en uit
+- Zet de [Verlichting van de Meetlocatie](#verlichting-van-de-meetlocatie-aan-en-uit) aan en uit
 - [Herhaal meting](#herhaal-meting)
-- De [Actie annuleren](#cancel-the-action)
+- De [Actie annuleren](#annuleer-de-actie)
 
 {{% alert title="Hint" %}}
 Als de temperatuur in het gele gebied ("verhoogd") of rode gebied ("koorts") is, plaatst VitalControl automatisch het geselecteerde dier op de alarmlijst. Door correlatie met andere gegevens kunt u de gezondheid van het individuele dier continu monitoren.

--- a/content/nl/docs/acties/weight.md
+++ b/content/nl/docs/acties/weight.md
@@ -37,7 +37,7 @@ Als het gemiddelde gewicht sterk afwijkt in één richting (te hoog/te laag), mo
 {{< /tabpane >}}
 
 {{% alert title="Tip" %}}
-Als deze actie niet beschikbaar is, is de actie waarschijnlijk gedeactiveerd! Activeer de actie in het [actie-instellingen](/nl/docs/acties/settings/#menuonderdelen) menu. Als alternatief zal het resetten van alle acties deze actie weer beschikbaar maken.
+Als deze actie niet beschikbaar is, is de actie waarschijnlijk gedeactiveerd! Activeer de actie in het [actie-instellingen](/nl/docs/acties/instellingen/) menu. Als alternatief zal het resetten van alle acties deze actie weer beschikbaar maken.
 {{% /alert %}}
 
 Please paste the Markdown content you want translated into Dutch.

--- a/content/nl/docs/animal/_index.md
+++ b/content/nl/docs/animal/_index.md
@@ -22,7 +22,7 @@ De functie voor individuele dieren stelt u in staat belangrijke informatie te be
  ![VitalControl: Menu Dier](images/list.png "Weergeven als een lijst")
 
 {{% alert title="Hint"  %}}
-Binnen elke informatieweergave heeft u de optie om [naar een dier te zoeken](#search-animal), een [filter in te stellen](#set-filter) en over te schakelen naar een [grafische weergave](#set-graphical-view).
+Binnen elke informatieweergave heeft u de optie om [naar een dier te zoeken](#dier-zoeken), een [filter in te stellen](#filter-instellen) en over te schakelen naar een [grafische weergave](#grafische-weergave-instellen).
 U kunt ook op elk moment tussen de individuele dieren schakelen met de pijltoetsen ◁ ▷.
 {{% /alert %}}
 

--- a/content/nl/docs/data-export/data-files.md
+++ b/content/nl/docs/data-export/data-files.md
@@ -14,10 +14,10 @@ translationKey: data-export/data-files
 
 Bij het exporteren van diergegevens, ongeacht of dit naar de [USB-stick][] of naar een lokale massaalopslagapparaat [op de PC][], worden in elk geval vier exportbestanden gegenereerd:
 
-- [Diergegevens][] `(animals.csv)`
-- [Gegevens over lichaamstemperatuur][] `(temperatures.csv)`
-- [Gewichtsgegevens][] `(weights.csv)`
-- [Beoordelingen van dieren][] `(ratings.csv)`
+- [Diergegevens](#diergegevens-animalscsv) `(animals.csv)`
+- [Gegevens over lichaamstemperatuur](#lichaamstemperatuurgegevens-temperaturescsv)`(temperatures.csv)`
+- [Gewichtsgegevens](#gewichtsgegevens-weightscsv) `(weights.csv)`
+- [Beoordelingen van dieren](#dierbeoordelingen-ratingscsv) `(ratings.csv)`
 
 [USB-stick]: ../usb-drive/
 [op de PC]: ../pc/

--- a/content/nl/docs/data-export/usb-drive.md
+++ b/content/nl/docs/data-export/usb-drive.md
@@ -27,7 +27,7 @@ translationKey: data-export/usb-drive
 
    ![VitalControl: succesmelding gegevensexport](../images/success-data-export.png "Succes gegevensexport")
 
-5. De gegevensexport is nu voltooid. U vindt de vier gecreëerde [exportbestanden](../export-files/) in de map `export-csv` op uw USB-stick.
+5. De gegevensexport is nu voltooid. U vindt de vier gecreëerde [exportbestanden](../export-bestanden/) in de map `export-csv` op uw USB-stick.
 
    ![USB-stick met exportbestanden VitalControl](../images/export-files.png "Exportbestanden op USB-stick")
 

--- a/content/nl/docs/data-link/farm-pc/_index.md
+++ b/content/nl/docs/data-link/farm-pc/_index.md
@@ -33,12 +33,12 @@ Als u het item `Urban VitalControl` niet kunt vinden in uw applicatielijst, moet
 
    ![Windows Startmenu, menu-item voor Urban VitalControl (VCSynchronizer)](../vcsynchronizer/images/data-export/data-export.png "Windows startmenu, VitalControl")
 
-1. Het exportproces wordt gestart. Zodra de gegevensexport is voltooid, opent een Verkenner-venster dat de lokale gegevensdirectory toont met de vier nieuw aangemaakte [exportbestanden](../../data-export/export-files/).
+1. Het exportproces wordt gestart. Zodra de gegevensexport is voltooid, opent een Verkenner-venster dat de lokale gegevensdirectory toont met de vier nieuw aangemaakte [exportbestanden](../../data-export/export-bestanden/).
 
    ![Lokale gegevensdirectory met exportbestanden](../../data-export/images/export-files.png "Exportbestanden, lokaal opgeslagen")
 
    {{% alert title="Opmerking" %}}
-  U kunt elk van deze vier [exportbestanden](../../data-export/export-files/) openen in een spreadsheetprogramma naar keuze (zoals [Microsoft Excel](https://products.office.com/excel) of [OpenOffice Calc](https://www.openoffice.org/)) en daar geavanceerde data-analyses uitvoeren. Als voorbeeld wordt hieronder de weergave van de tabel `animals.csv` in een spreadsheetprogramma getoond:
+  U kunt elk van deze vier [exportbestanden](../../data-export/export-bestanden/) openen in een spreadsheetprogramma naar keuze (zoals [Microsoft Excel](https://products.office.com/excel) of [OpenOffice Calc](https://www.openoffice.org/)) en daar geavanceerde data-analyses uitvoeren. Als voorbeeld wordt hieronder de weergave van de tabel `animals.csv` in een spreadsheetprogramma getoond:
 
 ![Geëxporteerde dierendata tabel geopend in spreadsheetsoftware](../../data-export/images/animals.png "Spreadsheetsoftware met dierendata")
 {{% /alert %}}

--- a/content/nl/docs/herd/_index.md
+++ b/content/nl/docs/herd/_index.md
@@ -15,13 +15,13 @@ translationKey: herd
 
 Binnen het menu-item Kudde kunt u uw gehele kudde bekijken, individuele dieren zoeken en belangrijke informatie weergeven. U heeft de volgende mogelijkheden:
 
-- Bekijk [diergegevens](#view-animal-data)
-- Bekijk [temperatuurgegevens](#display-temperatuur)
-- Bekijk [beoordelingsgegevens](#view-beoordeling)
-- Bekijk [gewichtsgegevens](#display-gewicht)
+- Bekijk [diergegevens](#diergegevens-bekijken)
+- Bekijk [temperatuurgegevens](#temperatuur-weergeven)
+- Bekijk [beoordelingsgegevens](#beoordeling-bekijken)
+- Bekijk [gewichtsgegevens](#gewicht-weergeven)
 - [Dier zoeken](#dier-zoeken)
-- [Filter instellen](#filter-zetten)
-- [Acties](#call-acties-menu)
+- [Filter instellen](#filter-instellen)
+- [Acties](#actiemenu-oproepen)
 
 ### Voorbereidende stappen
 

--- a/content/nl/docs/lists/_index.md
+++ b/content/nl/docs/lists/_index.md
@@ -19,7 +19,7 @@ Als u op een menu-item klikt, wordt u doorgestuurd naar een beschrijving van de 
   <area shape="rect" coords="3,280,116,399" alt="Droge koeien" title="Bekijk uw lijst met droge koeien&#10;Muisklik: open documentatie" href="/nl/docs/lists/dry-cows/">
 
   <area shape="rect" coords="116,40,230,160" alt="bekijken" title="Bekijk uw observatielijst&#10;Muisklik: open documentatie" href="/nl/docs/lists/on-watch/">
-  <area shape="rect" coords="116,160,230,280" alt="Verse koeien" title="Bekijk uw lijst met verse koeien&#10;Muisklik: open documentatie" href="/nl/docs/lists/verse-koeien/">
+  <area shape="rect" coords="116,160,230,280" alt="Verse koeien" title="Bekijk uw lijst met verse koeien&#10;Muisklik: open documentatie" href="/nl/docs/lists/fresh-cows/">
 
   <area shape="rect" coords="2,401,115,438" alt="Terug" title="Spring een niveau terug" href="/nl/docs/menu/mainmenu/">
 </map>

--- a/content/nl/docs/lists/alarm.md
+++ b/content/nl/docs/lists/alarm.md
@@ -20,7 +20,7 @@ Op de alarmlijst vindt u alle dieren die u handmatig aan de lijst heeft toegevoe
 - [Temperatuur meten](#temperatuur-meten)
 - [Dier beoordelen](#dier-beoordelen)
 - [Alarm terugzetten](#alarm-terug-zetten)
-- [Bewakingsstatus wisselen](#toggle-watch-status)
+- [Bewakingsstatus wisselen](#toogle-watch-status)
 - [Dier zoeken](#dier-zoeken)
 - [Filter instellen](#filter-zetten)
 
@@ -78,7 +78,7 @@ De alarmlijst is als volgt gestructureerd:
 
 3. Binnen de alarmlijst, gebruik de pijltoetsen △ ▽ om het gewenste dier te selecteren en bevestig met `OK`. Als alternatief kunt u zoeken naar een dier. Gebruik de `Aan/Uit` knop <img src="/icons/footer/search.svg" width="15" align="bottom" alt="Search" /> en gebruik de pijltoetsen ◁ ▷ △ ▽ om de gewenste cijfers te selecteren. Bevestig ten slotte met `OK`.
 
-4. De functie [Temperatuur meten](/nl/docs/acties/measure-temperature/#measure-fever) wordt nu automatisch gestart.
+4. De functie [Temperatuur meten](/nl/docs/acties/measure-temperature/) wordt nu automatisch gestart.
 
    ![VitalControl Lists Alarmlist](../images/temperature.png "Temperatuur meten")
 
@@ -90,7 +90,7 @@ De alarmlijst is als volgt gestructureerd:
 
 3. Binnen de alarmlijst, gebruik de pijltoetsen △ ▽ om het gewenste dier te selecteren en bevestig met `OK`. Als alternatief kunt u zoeken naar een dier. Gebruik de `Aan/Uit` knop <img src="/icons/footer/search.svg" width="15" align="bottom" alt="Search" /> en gebruik de pijltoetsen ◁ ▷ △ ▽ om de gewenste cijfers te selecteren. Bevestig ten slotte met `OK`.
 
-4. De functie [Dier beoordelen](/nl/docs/acties/rating/#rate-your-animals) wordt nu automatisch gestart.
+4. De functie [Dier beoordelen](/nl/docs/acties/rating/#beoordeel-uw-dieren) wordt nu automatisch gestart.
 
    ![VitalControl Lists Alarmlist](../images/rateanimal.png "Dier beoordelen")
 
@@ -134,6 +134,6 @@ De alarmlijst is als volgt gestructureerd:
 
 2. Gebruik de `F3` toets &nbsp;<img src="/icons/footer/open-popup.svg" width="15" align="bottom" alt="Open popup" />&nbsp; om een pop-upmenu op te roepen dat verschillende opties weergeeft. Gebruik de pijltoetsen △ ▽ om de functie `Filter zetten` te markeren en roep de filterfunctie op door op de centrale `OK` toets of de `F3` toets `OK` te drukken.
 
-3. Stel het gewenste filter in. U kunt hier vinden hoe u het filter gebruikt [hier](../../filter/#applying-filters).
+3. Stel het gewenste filter in. U kunt hier vinden hoe u het filter gebruikt [hier](../../filter/).
 
    ![VitalControl Lists Alarmlist](../images/setfilter.png "Filter instellen")

--- a/content/nl/docs/lists/dry-cows.md
+++ b/content/nl/docs/lists/dry-cows.md
@@ -19,8 +19,8 @@ Op de lijst van droge dieren vindt u alle dieren die u als droge dieren hebt opg
 - [Dier data](../alarm/#dier-data)
 - [Temperatuur meten](../alarm/#temperatuur-meten)
 - [Kalving](#kalving)
-- [Toggle alarm status](../on-watch/#toggle-alarm-status)
-- [Toggle watch status](../alarm/#toggle-watch-status)
+- [Toogle alarm status](../on-watch/#toggle-alarm-status)
+- [Toogle watch status](../alarm/#toogle-watch-status)
 - [Dier zoeken](../alarm/#dier-zoeken)
 - [Filter zetten](../alarm/#filter-zetten)
 

--- a/content/nl/docs/lists/freshcows.md
+++ b/content/nl/docs/lists/freshcows.md
@@ -17,7 +17,7 @@ translationKey: lists/fresh-cows
 Bij het beheren van verse koeien wordt het dagelijks controleren van de dieren gedurende meerdere dagen na de geboorte beschouwd als een beste praktijk routine. De lijst van verse koeien ondersteunt deze controle van verse koeien, vooral wat betreft het registreren van de temperatuur. Voor elk dier wordt een kolomdiagram over alle dagen van de controleperiode getoond, elke dag van de controleperiode wordt vertegenwoordigd door een verticale balk. Afhankelijk van de kleur van de balk (groen, geel of rood), kunt u zien of er op die dag een normale, verhoogde of kritisch verhoogde temperatuur is gemeten voor het betreffende dier.
 {{% /alert %}}
 
-Koeien worden direct na hun kalverenregistratie op de lijst van verse koeien geplaatst. Ze blijven gedurende een bepaalde periode op die lijst staan, de lengte van deze periode (in dagen) kan worden aangepast in de [instellingen](../../instellingen/data-acquisitie/#controle-periode-verse-koeien).
+Koeien worden direct na hun kalverenregistratie op de lijst van verse koeien geplaatst. Ze blijven gedurende een bepaalde periode op die lijst staan, de lengte van deze periode (in dagen) kan worden aangepast in de [instellingen](../../settings/data-acquisition/#controleperiode-verse-koeien).
  De volgende acties zijn beschikbaar voor deze lijst:
 
 - [Actiemenu](../alarm/#actiemenu)

--- a/content/nl/docs/lists/on-watch.md
+++ b/content/nl/docs/lists/on-watch.md
@@ -22,7 +22,7 @@ Op de lijst van geobserveerde dieren vindt u alle dieren die u handmatig aan de 
 - [Verwijder van Watchlist](#verwijder-van-watchlist)
 - [Toggle alarm status](#toggle-alarm-status)
 - [Dier zoeken](/nl/docs/lists/alarm/#dier-zoeken)
-- [Filter instellen](/nl/docs/lists/alarm/#filter-zetten)
+- [Filter instellen](../alarm/#filter-zetten)
 
 {{% alert title="Hint" %}}
 Sommige acties worden op dezelfde manier uitgevoerd als in de [Alarmlijst](../alarm). Deze worden hier niet uitgelegd. Voer de voorbereidende stappen uit en gebruik de link van de betreffende actie om naar de instructies te gaan.

--- a/content/nl/docs/new-on-farm/births.md
+++ b/content/nl/docs/new-on-farm/births.md
@@ -65,6 +65,6 @@ Het bewerken van de diergegevens is alleen mogelijk in de lijstweergave!
 
 1. Gebruik de pijltoetsen △ ▽ om het dier te selecteren dat u wilt bewerken en bevestig met `OK`.
 
-2. Er opent een submenu waarin u verschillende instellingen kunt aanpassen. Voor stapsgewijze instructies klik [hier](/nl/docs/new/calving/#register-a-kalving).
+2. Er opent een submenu waarin u verschillende instellingen kunt aanpassen. Voor stapsgewijze instructies klik [hier](/nl/docs/new/calving/#een-kalving-registreren).
 
     ![VitalControl: Menu Nieuw op boerderij Geboorten](../images/edit2.png "Bewerk een geboortemelding")

--- a/content/nl/docs/settings/collection-of-animal-data.md
+++ b/content/nl/docs/settings/collection-of-animal-data.md
@@ -23,7 +23,7 @@ De volgende afbeelding toont de beschikbare instellingen met betrekking tot het 
   <area shape="rect" coords="3,80,239,160" alt="Dierevaluatie" title="Stel de modus van dierbeoordeling in&#10;Muisklik: open documentatie" href="#dierevaluatie">
   <area shape="rect" coords="3,160,239,240" alt="Controleperiode verse koeien" title="Stel de lengte van de controleperiode voor verse koeien in&#10;Muisklik: open documentatie" href="#controleperiode-verse-koeien">
 
-  <area shape="rect" coords="2,282,125,318" alt="Terug" title="Ga een niveau terug" href="/nl/docs/instellingen/">
+  <area shape="rect" coords="2,282,125,318" alt="Terug" title="Ga een niveau terug" href="/nl/docs/settings/">
 </map>
 
 {{% alert title="Tip" %}}
@@ -161,7 +161,7 @@ Om de `Dierevaluatie` op uw apparaat in te stellen, gaat u als volgt te werk.
 ## Controleperiode verse koeien
 
 {{% alert title="Uitleg" %}}
-Bij het beheren van verse koeien wordt het dagelijks controleren van de dieren gedurende meerdere dagen na de geboorte, inclusief het meten van hun temperatuur, beschouwd als een beste praktijk. De duur van deze controleperiode varieert aanzienlijk van boerderij tot boerderij. Om deze reden kan de lengte van de controleperiode worden ingesteld op een waarde tussen 3 en 14 dagen in de VitalControl-instellingen. De ingestelde waarde voor de controleperiode van verse koeien bepaalt het aantal kolommen van de kolomgrafiek die voor elk dier wordt weergegeven in de [lijst met verse koeien](../../lists/verse-koeien/).
+Bij het beheren van verse koeien wordt het dagelijks controleren van de dieren gedurende meerdere dagen na de geboorte, inclusief het meten van hun temperatuur, beschouwd als een beste praktijk. De duur van deze controleperiode varieert aanzienlijk van boerderij tot boerderij. Om deze reden kan de lengte van de controleperiode worden ingesteld op een waarde tussen 3 en 14 dagen in de VitalControl-instellingen. De ingestelde waarde voor de controleperiode van verse koeien bepaalt het aantal kolommen van de kolomgrafiek die voor elk dier wordt weergegeven in de [lijst met verse koeien](../../lists/fresh-cows/).
 {{% /alert %}}
 
 Om de lengte van de controleperiode voor uw verse koeien in te stellen, gaat u als volgt te werk:


### PR DESCRIPTION
Alle Link-Errors bereinigt. Bitte unbedingt die hugo.yml überprüfen, ich glaub ich habe vergessen das # vor dem -print weg zunehmen.