### PR TITLE
Extension of adding shortcode for retrieving firmware versions

### DIFF
--- a/content/bg/docs/firmware/versions.md
+++ b/content/bg/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Следната таблица изброява текущите версии на фърмуера:
 
-|                 | GUI-Фърмуер | Middleware  | Зареждаща програма |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Версия**      | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Дата**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Хеш на комит** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **№ на комит**  | 2076         | n/a         | n/a        |
+|                 | GUI-Фърмуер  | Middleware | Зареждаща програма |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Версия**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Дата**        | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Хеш на комит**  | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **№ на комит**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Съвет" %}}
 Ако липсват по-нови функции на вашето устройство или имате проблеми със стабилността, препоръчва се [актуализация](../update/) на фърмуера на вашето устройство до последната издадена версия.

--- a/content/bs/docs/firmware/versions.md
+++ b/content/bs/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Sledeća tabela prikazuje trenutne verzije firmvera:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Verzija**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Datum**       | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Verzija**    | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Savjet" %}}
 Ako vam nedostaju novije funkcije na vašem uređaju ili imate problema sa stabilnošću, preporučuje se da [ažurirate](../update/) firmver na vašem uređaju na najnoviju verziju.

--- a/content/cs/docs/firmware/versions.md
+++ b/content/cs/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Následující tabulka uvádí aktuální verze firmwaru:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Verze**       | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Datum**       | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Verze**  | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tip" %}}
 Pokud vám na vašem zařízení chybí novější funkce nebo máte problémy se stabilitou, doporučujeme [aktualizovat](../update/) firmware na vašem zařízení na nejnovější vydanou verzi.

--- a/content/da/docs/firmware/versions.md
+++ b/content/da/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Følgende tabel viser de nuværende firmware-versioner:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Version**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Dato**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Version**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Dato**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tip" %}}
 Hvis du mangler nyere funktioner på din enhed eller oplever stabilitetsproblemer, opfordres du til at [opdatere](../update/) firmwaren på din enhed til den senest udgivne version.

--- a/content/de/docs/firmware/versions.md
+++ b/content/de/docs/firmware/versions.md
@@ -24,9 +24,9 @@ Die folgende Tabelle listet die aktuellen Firmware-Versionen auf:
 |                 | GUI-Firmware  | Middleware  | Bootloader |
 |-----------------|:-------------:|:-----------:|:----------:|
 | **Version**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
-| **Datum**       | 20.03.2024    | 20.03.2024  | 15.03.2024 |
-| **Commit Hash** | 1ad71d79      | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076          | n/a         | n/a        |
+| **Datum**       | {{% version/firmware component="gui-date-DE" %}} | {{% version/firmware component="middelware-date-DE" %}} | {{% version/firmware component="bootloader-date-DE" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tipp" %}}
 Falls Sie auf ihrem Gerät neuere Funktionen vermissen oder mit Stabilitätsproblemen konfrontiert sind, [aktualisieren](../update/) Sie ggf. die auf ihrem Gerät aufgespielte Firmwareversion.

--- a/content/el/docs/firmware/versions.md
+++ b/content/el/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Ο παρακάτω πίνακας απαριθμεί τις τρέχουσες εκδόσεις firmware:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Έκδοση**      | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Ημερομηνία**  | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Κωδικός commit** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Αριθμός commit** | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Έκδοση**      | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Ημερομηνία**     | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Κωδικός commit** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Αριθμός commit**   | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Συμβουλή" %}}
 Εάν σας λείπουν νεότερες δυνατότητες στη συσκευή σας ή αντιμετωπίζετε προβλήματα σταθερότητας, σας συνιστούμε να [ενημερώσετε](../update/) το firmware στη συσκευή σας στην τελευταία κυκλοφορημένη έκδοση.

--- a/content/en/docs/firmware/versions.md
+++ b/content/en/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 The following table lists the current firmware versions:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Version**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Date**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Version**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tip" %}}
 If you miss newer features on your device or face stability problems, you are encouraged to [update](../update/) the firmware on your device to latest released version.

--- a/content/es/docs/firmware/versions.md
+++ b/content/es/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 La siguiente tabla lista las versiones actuales de firmware:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versión**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Fecha**       | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Hash de commit** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Número de commit**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versión**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Fecha**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Hash de commit** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Número de commit**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Consejo" %}}
 Si echa en falta nuevas características en su dispositivo o enfrenta problemas de estabilidad, se recomienda [actualizar](../update/) el firmware de su dispositivo a la última versión lanzada.

--- a/content/et/docs/firmware/versions.md
+++ b/content/et/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Järgnev tabel loetleb praegused püsivara versioonid:
 
-|                 | GUI-püsivara | Tarkvara vahenduskiht  | Alglaadur |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versioon**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Kuupäev**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Kommiti hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Kommiti №**    | 2076         | n/a         | n/a        |
+|                 | GUI-püsivara  | Tarkvara vahenduskiht  | Alglaadur |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versioon**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Kuupäev**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Kommiti Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Kommiti №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Nipp" %}}
 Kui sinu seadmel puuduvad uuemad funktsioonid või esineb stabiilsusprobleeme, soovitame [uuendada](../update/) seadme püsivara viimase välja antud versioonini.

--- a/content/fi/docs/firmware/versions.md
+++ b/content/fi/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Seuraava taulukko listaa nykyiset laiteohjelmistoversiot:
 
-|                 | GUI-laiteohjelmisto | Väliohjelmisto  | Käynnistyslataaja |
-|-----------------|:-------------------:|:---------------:|:-----------------:|
-| **Versio**      | 0.9.9               | 0.9.9           | 1.0.6             |
-| **Päivämäärä**  | 20.03.2024          | 20.03.2024      | 15.03.2024        |
-| **Commit hash** | 1ad71d79            | 4d7f851         | 344bc50           |
-| **Commit №**    | 2076                | n/a             | n/a               |
+|                 | GUI-laiteohjelmisto  | Väliohjelmisto  | Käynnistyslataaja |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versio**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Päivämäärä**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Vinkki" %}}
 Jos kaipaat laitteeseesi uudempia ominaisuuksia tai kohtaat vakausongelmia, suosittelemme [päivittämään](../update/) laitteesi laiteohjelmiston uusimpaan julkaistuun versioon.

--- a/content/fr/docs/firmware/versions.md
+++ b/content/fr/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Le tableau suivant liste les versions actuelles du firmware :
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Version**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Date**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Version**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Conseil" %}}
 Si vous manquez de nouvelles fonctionnalités sur votre dispositif ou rencontrez des problèmes de stabilité, nous vous encourageons à [mettre à jour](../update/) le firmware sur votre dispositif vers la dernière version disponible.

--- a/content/hr/docs/firmware/versions.md
+++ b/content/hr/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Sljedeća tablica prikazuje trenutne verzije firmvera:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Verzija**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Datum**       | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Verzija**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Savjet" %}}
 Ako vam nedostaju novije značajke na vašem uređaju ili imate problema sa stabilnošću, preporučuje se [ažurirati](../update/) firmver na vašem uređaju na najnoviju objavljenu verziju.

--- a/content/hu/docs/firmware/versions.md
+++ b/content/hu/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 A következő táblázat az aktuális firmware verziókat sorolja fel:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Verzió**      | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Dátum**       | 2024.03.20   | 2024.03.20  | 2024.03.15 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Verzió**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Dátum**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tipp" %}}
 Ha újabb funkciókat hiányol az eszközén, vagy stabilitási problémákkal szembesül, javasoljuk, hogy [frissítse](../update/) az eszköz firmware-jét a legújabb kiadott verzióra.

--- a/content/it/docs/firmware/versions.md
+++ b/content/it/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 La seguente tabella elenca le versioni attuali del firmware:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versione**    | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Data**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versione**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Data**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Suggerimento" %}}
 Se ti mancano nuove funzionalità sul tuo dispositivo o riscontri problemi di stabilità, ti consigliamo di [aggiornare](../update/) il firmware del tuo dispositivo all'ultima versione rilasciata.

--- a/content/lt/docs/firmware/versions.md
+++ b/content/lt/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Šioje lentelėje pateikiamos dabartinės programinės įrangos versijos:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versija**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Data**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versija**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Data**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Patarimas" %}}
 Jei jūsų įrenginyje trūksta naujesnių funkcijų arba susiduriate su stabilumo problemomis, rekomenduojame [atnaujinti](../update/) įrenginio programinę įrangą į naujausią išleistą versiją.

--- a/content/nl/docs/firmware/versions.md
+++ b/content/nl/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 De volgende tabel toont de huidige firmwareversies:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versie**      | 0.9.9        | 0.9.9       | 1.0.4      |
-| **Datum**       | 2023-09-05   | 2023-09-06  | 2023-05-03 |
-| **Commit hash** | ad516b18     | 5c2c5cb     | d3d2a3d    |
-| **Commit №**    | 1931         | n.v.t.      | n.v.t.     |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versie**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tip" %}}
 Als u nieuwere functies mist op uw apparaat of stabiliteitsproblemen ondervindt, wordt u aangeraden de firmware op uw apparaat [bij te werken](../update/) naar de nieuwste uitgebrachte versie.

--- a/content/no/docs/firmware/versions.md
+++ b/content/no/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Følgende tabell viser de nåværende firmware-versjonene:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versjon**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Dato**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versjon**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Dato**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tips" %}}
 Hvis du mangler nyere funksjoner på enheten din eller opplever stabilitetsproblemer, oppfordres du til å [oppdatere](../update/) firmwaren på enheten din til den nyeste utgitte versjonen.

--- a/content/pl/docs/firmware/versions.md
+++ b/content/pl/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Poniższa tabela przedstawia aktualne wersje oprogramowania:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Wersja**      | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Data**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Wersja**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Data**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Wskazówka" %}}
 Jeśli brakuje Ci nowszych funkcji na Twoim urządzeniu lub napotykasz problemy ze stabilnością, zaleca się [zaktualizowanie](../update/) oprogramowania na urządzeniu do najnowszej wersji.

--- a/content/pt/docs/firmware/versions.md
+++ b/content/pt/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 A tabela a seguir lista as versões atuais de firmware:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versão**      | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Data**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versão**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Dica" %}}
 Se você sentir falta de novos recursos no seu dispositivo ou enfrentar problemas de estabilidade, é recomendável [atualizar](../update/) o firmware do seu dispositivo para a versão mais recente lançada.

--- a/content/ro/docs/firmware/versions.md
+++ b/content/ro/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Următorul tabel listează versiunile actuale de firmware:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Versiune**    | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Data**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Versiune**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Data**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Sfat" %}}
 Dacă vă lipsesc funcții noi pe dispozitivul dvs. sau întâmpinați probleme de stabilitate, vă recomandăm să [actualizați](../update/) firmware-ul dispozitivului dvs. la cea mai recentă versiune lansată.

--- a/content/ru/docs/firmware/versions.md
+++ b/content/ru/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 В следующей таблице перечислены текущие версии прошивок:
 
-|                 | GUI-Прошивка | Промежуточное ПО  | Загрузчик |
-|-----------------|:------------:|:----------------:|:---------:|
-| **Версия**      | 0.9.9        | 0.9.9            | 1.0.6     |
-| **Дата**        | 20.03.2024   | 20.03.2024       | 15.03.2024 |
-| **Хеш коммита** | 1ad71d79     | 4d7f851          | 344bc50   |
-| **№ коммита**   | 2076         | n/a              | n/a       |
+|                 | GUI-Прошивка  | Промежуточное ПО  | Загрузчик |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Версия**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Дата**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Хеш коммита** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **№ коммита**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Совет" %}}
 Если вы не обнаруживаете новых функций на вашем устройстве или сталкиваетесь с проблемами стабильности, рекомендуется [обновить](../update/) прошивку вашего устройства до последней выпущенной версии.

--- a/content/sl/docs/firmware/versions.md
+++ b/content/sl/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Naslednja tabela prikazuje trenutne različice vdelane programske opreme:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Različica**   | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Datum**       | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Različica**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Nasvet" %}}
 Če pogrešate novejše funkcije na vaši napravi ali imate težave s stabilnostjo, vam priporočamo, da [posodobite](../update/) vdelano programsko opremo na vaši napravi na najnovejšo izdano različico.

--- a/content/sv/docs/firmware/versions.md
+++ b/content/sv/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Följande tabell listar de aktuella firmware-versionerna:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Version**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Datum**       | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Version**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Tips" %}}
 Om du saknar nyare funktioner på din enhet eller stöter på stabilitetsproblem, rekommenderas du att [uppdatera](../update/) firmware på din enhet till den senaste släppta versionen.

--- a/content/tr/docs/firmware/versions.md
+++ b/content/tr/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 Aşağıdaki tablo mevcut yazılım sürümlerini listeler:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Version**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Date**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Version**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="İpucu" %}}
 Cihazınızda daha yeni özellikleri kaçırıyorsanız veya kararlılık sorunları yaşıyorsanız, cihazınızdaki yazılımı en son sürüme [güncellemenizi](../update/) öneririz.

--- a/content/uk/docs/firmware/versions.md
+++ b/content/uk/docs/firmware/versions.md
@@ -20,12 +20,12 @@ description: >
 
 У наступній таблиці наведено поточні версії прошивки:
 
-|                 | GUI-Firmware | Middleware  | Bootloader |
-|-----------------|:------------:|:-----------:|:----------:|
-| **Version**     | 0.9.9        | 0.9.9       | 1.0.6      |
-| **Date**        | 20.03.2024   | 20.03.2024  | 15.03.2024 |
-| **Commit hash** | 1ad71d79     | 4d7f851     | 344bc50    |
-| **Commit №**    | 2076         | n/a         | n/a        |
+|                 | GUI-Firmware  | Middleware  | Bootloader |
+|-----------------|:-------------:|:-----------:|:----------:|
+| **Version**     | {{% version/firmware component="gui" %}} | {{% version/firmware component="middleware" %}} | {{% version/firmware component="bootloader" %}} |
+| **Date**       | {{% version/firmware component="gui-date" %}} | {{% version/firmware component="middelware-date" %}} | {{% version/firmware component="bootloader-date" %}} |
+| **Commit Hash** | {{% version/firmware component="gui-commitHash" %}} | {{% version/firmware component="middelware-commitHash" %}} |  {{% version/firmware component="bootloader-commitHash" %}} |
+| **Commit №**    | {{% version/firmware component="gui-commitNo" %}} | {{% version/firmware component="middelware-commitNo" %}} | {{% version/firmware component="bootloader-commitNo" %}}|
 
 {{% alert title="Порада" %}}
 Якщо ви не бачите нових функцій на вашому пристрої або стикаєтеся з проблемами стабільності, рекомендується [оновити](../update/) прошивку на вашому пристрої до останньої випущеної версії.

--- a/layouts/shortcodes/version/firmware.html
+++ b/layouts/shortcodes/version/firmware.html
@@ -1,8 +1,8 @@
 {{ $_component := .Get "component" -}}
 {{ with $_component -}}
-  {{ $matched := findRE "^(gui|middleware|bootloader)$" . -}}
+  {{ $matched := findRE "^(gui|middleware|bootloader|gui-date|middelware-date|bootloader-date|gui-date-DE|middelware-date-DE|bootloader-date-DE|gui-commitHash|middelware-commitHash|bootloader-commitHash|gui-commitNo|middelware-commitNo|bootloader-commitNo)$" . -}}
   {{ if not $matched -}}
-    {{ errorf "Shortcode %q: parameter %q should be one of 'gui', 'middleware', or 'bootloader'; but got %s. Error position: %s" $.Name "persist" $_component $.Position  -}}
+    {{ errorf "Shortcode %q: parameter %q should be one of 'gui', 'middleware',, 'bootloader', 'gui-date', 'middelware-date', 'bootloader-date-DE', 'gui-date-DE', 'middelware-date-DE', 'bootloader-date', 'gui-commitHash', 'middelware-commitHash', 'bootloader-commitHash', 'gui-commitNo', 'middelware-commitNo' or 'bootloader-commitNo'; but got %s. Error position: %s" $.Name "persist" $_component $.Position  -}}
   {{ end -}}
   {{ if eq $_component "gui" -}}
 0.9.9
@@ -10,5 +10,29 @@
 0.9.9
   {{- else if eq $_component "bootloader" -}}
 1.06
+  {{- else if eq $_component "gui-date-DE" -}}
+20.03.2024
+  {{- else if eq $_component "middelware-date-DE" -}}
+20.03.2024
+  {{- else if eq $_component "bootloader-date-DE" -}}  
+15.03.2024
+  {{- else if eq $_component "gui-date" -}}
+2024-03-20
+  {{- else if eq $_component "middelware-date" -}}
+2024-03-20
+  {{- else if eq $_component "bootloader-date" -}}  
+2024-03-15
+  {{- else if eq $_component "gui-commitHash" -}}
+1ad71d79 
+  {{- else if eq $_component "middelware-commitHash" -}}
+4d7f851
+  {{- else if eq $_component "bootloader-commitHash" -}}
+344bc50
+  {{- else if eq $_component "gui-commitNo" -}}
+  2076
+  {{- else if eq $_component "middelware-commitNo" -}}
+n/a 
+  {{- else if eq $_component "bootloader-commitNo" -}}
+n/a 
   {{- end -}}
 {{ end -}}


### PR DESCRIPTION
Extension of commit f418044: Add shortcode for retrieving firmware versions

- The table in docs/firmware/versions.md has been adjusted to support different date formats based on the language.
- For Germany, the format DD.MM.YYYY is now used.
- All other languages continue to follow the standard YYYY-MM-DD format.
- the document layouts/version/firmware.html got the needed updates

