### PR TITLE
Dokumentation: Broken links in `data-link/alma-pro/synchronisation`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: deining/actions-hugo@23c742ac548b48b5db7f35074895505e8a06d6db # v3.1.0-0
         with:
-          hugo-version: '0.149.0'
+          hugo-version: '0.149.1'
           withdeploy: true
           extended: true
 

--- a/content/bg/docs/data-link/alma-pro/synchronisation.md
+++ b/content/bg/docs/data-link/alma-pro/synchronisation.md
@@ -42,7 +42,7 @@ aliases: /vc/sync/bg
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Внимание</span><br>
-        За да стартирате синхронизацията на устройството VitalControl, трябва да сте влезли в системата с роля на потребител <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. В противен случай, бутонът <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> в <a href="#synchronise-vc-ap" >Меню за синхронизация</a> е деактивиран.
+        За да стартирате синхронизацията на устройството VitalControl, трябва да сте влезли в системата с роля на потребител <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. В противен случай, бутонът <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> в <a href="#figure3_synchronize_vitalcontrol_alma_pro">Меню за синхронизация</a> е деактивиран.
     </div>
 </div>
 
@@ -62,7 +62,7 @@ aliases: /vc/sync/bg
 
 1. Сега ще се появи екранът за синхронизация. Кликнете върху бутона <img src="/digits/3_negative_circled.svg" id ="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` в средата долу, за да започнете синхронизацията с устройството VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/bs/docs/data-link/alma-pro/synchronisation.md
+++ b/content/bs/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Da biste izvršili sinhronizaciju između automatskog hranilice Alma Pro i uređ
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Pažnja</span><br>
-        Da biste pokrenuli sinhronizaciju uređaja VitalControl, morate biti prijavljeni na mašinu u korisničkoj ulozi <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. U suprotnom, dugme <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> u <a href="#synchronise-vc-ap" >meniju za sinhronizaciju</a> je onemogućeno.
+        Da biste pokrenuli sinhronizaciju uređaja VitalControl, morate biti prijavljeni na mašinu u korisničkoj ulozi <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. U suprotnom, dugme <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> u <a href="#figure3_synchronize_vitalcontrol_alma_pro">meniju za sinhronizaciju</a> je onemogućeno.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Da biste izvršili sinhronizaciju između automatskog hranilice Alma Pro i uređ
 
 1. Sada će se pojaviti ekran za sinhronizaciju. Kliknite na dugme <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` u sredini na dnu da biste započeli sinhronizaciju s uređajem VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/cs/docs/data-link/alma-pro/synchronisation.md
+++ b/content/cs/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Pro provedení synchronizace mezi automatickým krmítkem Alma Pro a zařízení
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Pozor</span><br>
-        Aby bylo možné zahájit synchronizaci zařízení VitalControl, musíte být přihlášeni k zařízení v uživatelské roli <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Jinak je tlačítko <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> v <a href="#synchronise-vc-ap" >menu Synchronizace</a> deaktivováno.
+        Aby bylo možné zahájit synchronizaci zařízení VitalControl, musíte být přihlášeni k zařízení v uživatelské roli <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Jinak je tlačítko <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> v <a href="#figure3_synchronize_vitalcontrol_alma_pro">menu Synchronizace</a> deaktivováno.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Pro provedení synchronizace mezi automatickým krmítkem Alma Pro a zařízení
 
 1. Nyní se objeví obrazovka synchronizace. Klikněte na tlačítko <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="číslo 3 v kruhu" title="číslo 3" /> `{{<T "Synchronize" >}}` uprostřed dole pro zahájení synchronizace se zařízením VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/da/docs/data-link/alma-pro/synchronisation.md
+++ b/content/da/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ For at udføre synkronisering mellem Alma Pro automatisk foderautomat og VitalCo
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Bemærk</span><br>
-        For at starte synkroniseringen af VitalControl-enheden skal du være logget på maskinen i brugerrollen <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Ellers er knappen <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> i <a href="#synchronise-vc-ap" >Synkroniseringsmenuen</a> deaktiveret.
+        For at starte synkroniseringen af VitalControl-enheden skal du være logget på maskinen i brugerrollen <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Ellers er knappen <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> i <a href="#figure3_synchronize_vitalcontrol_alma_pro">Synkroniseringsmenuen</a> deaktiveret.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ For at udføre synkronisering mellem Alma Pro automatisk foderautomat og VitalCo
 
 1. Synkroniseringsskærmen vil nu blive vist. Klik på knappen <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` i midten nederst for at starte synkronisering med VitalControl-enheden.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/de/docs/data-link/alma-pro/synchronisation.md
+++ b/content/de/docs/data-link/alma-pro/synchronisation.md
@@ -51,7 +51,7 @@ Zur Durchführung einer Synchronisation zwischen dem Tränkeautomaten Alma Pro u
         </svg>
         <div>
             <span class="text-primary fs-3 fw-semibold">Achtung</span><br>
-            Um die Synchronisation des VitalControl-Geräts starten zu können, müssen Sie in der Benutzerrolle <span style="font-family: monospace; font-size: 90%;">Betriebsleiter</span> am Automaten angemeldet sein. Andernfalls ist die Schaltfläche <span style="font-family: monospace; font-size: 90%;">Synchronisieren</a> im <a href="#synchronise-vc-ap" >Synchronisationsmenü</a> deaktiviert.
+            Um die Synchronisation des VitalControl-Geräts starten zu können, müssen Sie in der Benutzerrolle <span style="font-family: monospace; font-size: 90%;">Betriebsleiter</span> am Automaten angemeldet sein. Andernfalls ist die Schaltfläche <span style="font-family: monospace; font-size: 90%;">Synchronisieren</a> im <a href="#figure3_synchronize_vitalcontrol_alma_pro">Synchronisationsmenü</a> deaktiviert.
         </div>
 </div>
 
@@ -71,7 +71,7 @@ Zur Durchführung einer Synchronisation zwischen dem Tränkeautomaten Alma Pro u
 
 1. Es wird jetzt der Synchronisationsbildschirm aufgerufen. Klicken Sie dort auf die unten mittig angeordnete Schaltfläche <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="Umrandete Ziffer 3" title="Ziffer 3" /> `Synchronisieren` um die Synchronisation mit dem VitalControl-Gerät zu starten.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/el/docs/data-link/alma-pro/synchronisation.md
+++ b/content/el/docs/data-link/alma-pro/synchronisation.md
@@ -42,7 +42,7 @@ aliases: /vc/sync/el
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Προσοχή</span><br>
-        Για να ξεκινήσετε τον συγχρονισμό της συσκευής VitalControl, πρέπει να είστε συνδεδεμένοι στη μηχανή με το ρόλο χρήστη <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Διαφορετικά, το κουμπί <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> στο <a href="#synchronise-vc-ap" >μενού Συγχρονισμού</a> είναι απενεργοποιημένο.
+        Για να ξεκινήσετε τον συγχρονισμό της συσκευής VitalControl, πρέπει να είστε συνδεδεμένοι στη μηχανή με το ρόλο χρήστη <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Διαφορετικά, το κουμπί <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> στο <a href="#figure3_synchronize_vitalcontrol_alma_pro">μενού Συγχρονισμού</a> είναι απενεργοποιημένο.
     </div>
 </div>
 
@@ -62,7 +62,7 @@ aliases: /vc/sync/el
 
 1. Η οθόνη συγχρονισμού θα εμφανιστεί τώρα. Κάντε κλικ στο κουμπί <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` στο κέντρο στο κάτω μέρος για να ξεκινήσετε το συγχρονισμό με τη συσκευή VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/en/docs/data-link/alma-pro/synchronisation.md
+++ b/content/en/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ To carry out synchronisation between the Alma Pro automatic feeder and the Vital
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Attention</span><br>
-        In order to start the synchronisation of the VitalControl device, you must be logged on to the machine in the user role <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Otherwise, the <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> button in the <a href="#synchronise-vc-ap" >Synchronisation menu</a> is disabled.
+        In order to start the synchronisation of the VitalControl device, you must be logged on to the machine in the user role <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Otherwise, the <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> button in the <a href="#figure3_synchronize_vitalcontrol_alma_pro">Synchronisation menu</a> is disabled.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ To carry out synchronisation between the Alma Pro automatic feeder and the Vital
 
 1. The synchronisation screen will now appear. Click on the button <img src="/digits/3_negative_circled.svg" id ="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` in the middle at the bottom to start synchronisation with the VitalControl device.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/es/docs/data-link/alma-pro/synchronisation.md
+++ b/content/es/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Para llevar a cabo la sincronización entre el comedero automático Alma Pro y e
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Atención</span><br>
-        Para iniciar la sincronización del dispositivo VitalControl, debe haber iniciado sesión en la máquina con el rol de usuario <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. De lo contrario, el botón <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> en el <a href="#synchronise-vc-ap" >menú de sincronización</a> estará deshabilitado.
+        Para iniciar la sincronización del dispositivo VitalControl, debe haber iniciado sesión en la máquina con el rol de usuario <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. De lo contrario, el botón <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> en el <a href="#figure3_synchronize_vitalcontrol_alma_pro">menú de sincronización</a> estará deshabilitado.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Para llevar a cabo la sincronización entre el comedero automático Alma Pro y e
 
 1. Ahora aparecerá la pantalla de sincronización. Haz clic en el botón <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="número 3 en círculo" title="número 3" /> `{{<T "Synchronize" >}}` en el medio en la parte inferior para iniciar la sincronización con el dispositivo VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/et/docs/data-link/alma-pro/synchronisation.md
+++ b/content/et/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Alma Pro automaatse söötja ja VitalControl seadme vahelise sünkroniseerimise 
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Tähelepanu</span><br>
-        VitalControl seadme sünkroniseerimise alustamiseks peate olema masinasse sisse logitud kasutaja rollis <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Vastasel juhul on <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> nupp <a href="#synchronise-vc-ap" >Sünkroniseerimise menüüs</a> keelatud.
+        VitalControl seadme sünkroniseerimise alustamiseks peate olema masinasse sisse logitud kasutaja rollis <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Vastasel juhul on <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> nupp <a href="#figure3_synchronize_vitalcontrol_alma_pro">Sünkroniseerimise menüüs</a> keelatud.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Alma Pro automaatse söötja ja VitalControl seadme vahelise sünkroniseerimise 
 
 1. Nüüd ilmub sünkroonimise ekraan. Klõpsake keskel allosas nuppu <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}`, et alustada sünkroonimist VitalControl seadmega.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/fi/docs/data-link/alma-pro/synchronisation.md
+++ b/content/fi/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Suorita synkronointi Alma Pro -automaattiruokkijan ja VitalControl-laitteen väl
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Huomio</span><br>
-        Jotta voit aloittaa VitalControl-laitteen synkronoinnin, sinun on oltava kirjautuneena koneelle käyttäjäroolissa <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Muuten <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> -painike <a href="#synchronise-vc-ap" >Synkronointivalikossa</a> on pois käytöstä.
+        Jotta voit aloittaa VitalControl-laitteen synkronoinnin, sinun on oltava kirjautuneena koneelle käyttäjäroolissa <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Muuten <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> -painike <a href="#figure3_synchronize_vitalcontrol_alma_pro">Synkronointivalikossa</a> on pois käytöstä.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Suorita synkronointi Alma Pro -automaattiruokkijan ja VitalControl-laitteen väl
 
 1. Synkronointinäyttö tulee nyt näkyviin. Klikkaa painiketta <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` keskellä alhaalla aloittaaksesi synkronoinnin VitalControl-laitteen kanssa.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/fr/docs/data-link/alma-pro/synchronisation.md
+++ b/content/fr/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Pour effectuer la synchronisation entre le distributeur automatique Alma Pro et 
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Attention</span><br>
-        Pour démarrer la synchronisation de l'appareil VitalControl, vous devez être connecté à la machine avec le rôle utilisateur <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Sinon, le bouton <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> dans le <a href="#synchronise-vc-ap" >menu de synchronisation</a> est désactivé.
+        Pour démarrer la synchronisation de l'appareil VitalControl, vous devez être connecté à la machine avec le rôle utilisateur <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Sinon, le bouton <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> dans le <a href="#figure3_synchronize_vitalcontrol_alma_pro">menu de synchronisation</a> est désactivé.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Pour effectuer la synchronisation entre le distributeur automatique Alma Pro et 
 
 1. L'écran de synchronisation apparaîtra maintenant. Cliquez sur le bouton <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="numéro 3 encerclé" title="numéro 3" /> `{{<T "Synchronize" >}}` au milieu en bas pour démarrer la synchronisation avec l'appareil VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/hr/docs/data-link/alma-pro/synchronisation.md
+++ b/content/hr/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Za provođenje sinkronizacije između automatskog hranilice Alma Pro i uređaja 
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Pažnja</span><br>
-        Da biste pokrenuli sinkronizaciju uređaja VitalControl, morate biti prijavljeni na uređaj u korisničkoj ulozi <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Inače, gumb <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> u <a href="#synchronise-vc-ap" >izborniku Sinkronizacija</a> je onemogućen.
+        Da biste pokrenuli sinkronizaciju uređaja VitalControl, morate biti prijavljeni na uređaj u korisničkoj ulozi <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Inače, gumb <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> u <a href="#figure3_synchronize_vitalcontrol_alma_pro">izborniku Sinkronizacija</a> je onemogućen.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Za provođenje sinkronizacije između automatskog hranilice Alma Pro i uređaja 
 
 1. Sada će se pojaviti zaslon za sinkronizaciju. Kliknite na gumb <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="broj 3 u krugu" title="broj 3" /> `{{<T "Synchronize" >}}` u sredini na dnu za pokretanje sinkronizacije s uređajem VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/hu/docs/data-link/alma-pro/synchronisation.md
+++ b/content/hu/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ A szinkronizáció végrehajtásához az Alma Pro automata etető és a VitalCon
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Figyelem</span><br>
-        A VitalControl eszköz szinkronizálásának megkezdéséhez be kell jelentkeznie a gépre a <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span> felhasználói szerepkörben. Ellenkező esetben a <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> gomb a <a href="#synchronise-vc-ap" >Szinkronizálás menüben</a> le van tiltva.
+        A VitalControl eszköz szinkronizálásának megkezdéséhez be kell jelentkeznie a gépre a <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span> felhasználói szerepkörben. Ellenkező esetben a <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> gomb a <a href="#figure3_synchronize_vitalcontrol_alma_pro">Szinkronizálás menüben</a> le van tiltva.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ A szinkronizáció végrehajtásához az Alma Pro automata etető és a VitalCon
 
 1. Most megjelenik a szinkronizációs képernyő. Kattintson a középen alul található <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` gombra a VitalControl eszközzel való szinkronizáció megkezdéséhez.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/it/docs/data-link/alma-pro/synchronisation.md
+++ b/content/it/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Per effettuare la sincronizzazione tra il distributore automatico Alma Pro e il 
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Attenzione</span><br>
-        Per avviare la sincronizzazione del dispositivo VitalControl, devi essere connesso alla macchina con il ruolo utente <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Altrimenti, il pulsante <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> nel <a href="#synchronise-vc-ap" >menu di sincronizzazione</a> è disabilitato.
+        Per avviare la sincronizzazione del dispositivo VitalControl, devi essere connesso alla macchina con il ruolo utente <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Altrimenti, il pulsante <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> nel <a href="#figure3_synchronize_vitalcontrol_alma_pro">menu di sincronizzazione</a> è disabilitato.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Per effettuare la sincronizzazione tra il distributore automatico Alma Pro e il 
 
 1. Ora apparirà la schermata di sincronizzazione. Clicca sul pulsante <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="numero 3 cerchiato" title="numero 3" /> `{{<T "Synchronize" >}}` al centro in basso per avviare la sincronizzazione con il dispositivo VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/lt/docs/data-link/alma-pro/synchronisation.md
+++ b/content/lt/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Norėdami atlikti sinchronizavimą tarp Alma Pro automatinės šėryklos ir Vita
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Dėmesio</span><br>
-        Norint pradėti VitalControl įrenginio sinchronizavimą, turite būti prisijungę prie įrenginio kaip vartotojas su vaidmeniu <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Priešingu atveju, <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> mygtukas <a href="#synchronise-vc-ap" >Sinchronizavimo meniu</a> bus išjungtas.
+        Norint pradėti VitalControl įrenginio sinchronizavimą, turite būti prisijungę prie įrenginio kaip vartotojas su vaidmeniu <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Priešingu atveju, <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> mygtukas <a href="#figure3_synchronize_vitalcontrol_alma_pro">Sinchronizavimo meniu</a> bus išjungtas.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Norėdami atlikti sinchronizavimą tarp Alma Pro automatinės šėryklos ir Vita
 
 1. Dabar pasirodys sinchronizacijos ekranas. Spustelėkite mygtuką <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="apskritime esantis skaičius 3" title="skaičius 3" /> `{{<T "Synchronize" >}}` apačioje viduryje, kad pradėtumėte sinchronizaciją su VitalControl įrenginiu.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/lv/docs/data-link/alma-pro/synchronisation.md
+++ b/content/lv/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Lai veiktu sinhronizāciju starp Alma Pro automātisko barotavu un VitalControl 
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Uzmanību</span><br>
-        Lai sāktu VitalControl ierīces sinhronizāciju, jums ir jābūt pieslēgtam pie iekārtas lietotāja lomā <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Pretējā gadījumā <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> poga <a href="#synchronise-vc-ap" >Sinhronizācijas izvēlnē</a> ir atspējota.
+        Lai sāktu VitalControl ierīces sinhronizāciju, jums ir jābūt pieslēgtam pie iekārtas lietotāja lomā <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Pretējā gadījumā <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> poga <a href="#figure3_synchronize_vitalcontrol_alma_pro">Sinhronizācijas izvēlnē</a> ir atspējota.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Lai veiktu sinhronizāciju starp Alma Pro automātisko barotavu un VitalControl 
 
 1. Tagad parādīsies sinhronizācijas ekrāns. Noklikšķiniet uz pogas <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` vidū apakšā, lai sāktu sinhronizāciju ar VitalControl ierīci.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/nl/docs/data-link/alma-pro/synchronisation.md
+++ b/content/nl/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Om synchronisatie uit te voeren tussen de Alma Pro automatische voederbak en het
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Let op</span><br>
-        Om de synchronisatie van het VitalControl-apparaat te starten, moet u aangemeld zijn op de machine in de gebruikersrol <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Anders is de knop <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> in het <a href="#synchronise-vc-ap" >Synchronisatiemenu</a> uitgeschakeld.
+        Om de synchronisatie van het VitalControl-apparaat te starten, moet u aangemeld zijn op de machine in de gebruikersrol <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Anders is de knop <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> in het <a href="#figure3_synchronize_vitalcontrol_alma_pro">Synchronisatiemenu</a> uitgeschakeld.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Om synchronisatie uit te voeren tussen de Alma Pro automatische voederbak en het
 
 1. Het synchronisatiescherm verschijnt nu. Klik op de knop <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="omcirkeld nummer 3" title="nummer 3" /> `{{<T "Synchronize" >}}` in het midden onderaan om de synchronisatie met het VitalControl apparaat te starten.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/no/docs/data-link/alma-pro/synchronisation.md
+++ b/content/no/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ For å utføre synkronisering mellom Alma Pro automatisk mater og VitalControl-e
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Oppmerksomhet</span><br>
-        For å starte synkroniseringen av VitalControl-enheten, må du være logget på maskinen i brukerrollen <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Ellers er <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span>-knappen i <a href="#synchronise-vc-ap" >Synkroniseringsmenyen</a> deaktivert.
+        For å starte synkroniseringen av VitalControl-enheten, må du være logget på maskinen i brukerrollen <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Ellers er <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span>-knappen i <a href="#figure3_synchronize_vitalcontrol_alma_pro">Synkroniseringsmenyen</a> deaktivert.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ For å utføre synkronisering mellom Alma Pro automatisk mater og VitalControl-e
 
 1. Synkroniseringsskjermen vil nå vises. Klikk på knappen <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` i midten nederst for å starte synkronisering med VitalControl-enheten.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/pl/docs/data-link/alma-pro/synchronisation.md
+++ b/content/pl/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Aby przeprowadzić synchronizację między automatycznym karmnikiem Alma Pro a u
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Uwaga</span><br>
-        Aby rozpocząć synchronizację urządzenia VitalControl, musisz być zalogowany na maszynie w roli użytkownika <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. W przeciwnym razie przycisk <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> w <a href="#synchronise-vc-ap" >menu Synchronizacji</a> jest wyłączony.
+        Aby rozpocząć synchronizację urządzenia VitalControl, musisz być zalogowany na maszynie w roli użytkownika <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. W przeciwnym razie przycisk <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> w <a href="#figure3_synchronize_vitalcontrol_alma_pro">menu Synchronizacji</a> jest wyłączony.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Aby przeprowadzić synchronizację między automatycznym karmnikiem Alma Pro a u
 
 1. Teraz pojawi się ekran synchronizacji. Kliknij przycisk <img src="/digits/3_negative_circled.svg"  id="StartSynchronisation_Digit_3" width="25" align="middle" alt="cyfra 3 w kółku" title="cyfra 3" /> `{{<T "Synchronize" >}}` na środku u dołu, aby rozpocząć synchronizację z urządzeniem VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/pt/docs/data-link/alma-pro/synchronisation.md
+++ b/content/pt/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Para realizar a sincronização entre o alimentador automático Alma Pro e o dis
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Atenção</span><br>
-        Para iniciar a sincronização do dispositivo VitalControl, você deve estar logado na máquina com o papel de usuário <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Caso contrário, o botão <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> no <a href="#synchronise-vc-ap" >menu de Sincronização</a> estará desativado.
+        Para iniciar a sincronização do dispositivo VitalControl, você deve estar logado na máquina com o papel de usuário <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Caso contrário, o botão <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> no <a href="#figure3_synchronize_vitalcontrol_alma_pro">menu de Sincronização</a> estará desativado.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Para realizar a sincronização entre o alimentador automático Alma Pro e o dis
 
 1. A tela de sincronização agora aparecerá. Clique no botão <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="número 3 em círculo" title="número 3" /> `{{<T "Synchronize" >}}` no meio, na parte inferior, para iniciar a sincronização com o dispositivo VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/ro/docs/data-link/alma-pro/synchronisation.md
+++ b/content/ro/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Pentru a efectua sincronizarea între hrănitorul automat Alma Pro și dispoziti
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Atenție</span><br>
-        Pentru a începe sincronizarea dispozitivului VitalControl, trebuie să fiți autentificat pe mașină cu rolul de utilizator <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. În caz contrar, butonul <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> din <a href="#synchronise-vc-ap" >meniul de sincronizare</a> este dezactivat.
+        Pentru a începe sincronizarea dispozitivului VitalControl, trebuie să fiți autentificat pe mașină cu rolul de utilizator <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. În caz contrar, butonul <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> din <a href="#figure3_synchronize_vitalcontrol_alma_pro">meniul de sincronizare</a> este dezactivat.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Pentru a efectua sincronizarea între hrănitorul automat Alma Pro și dispoziti
 
 1. Ecranul de sincronizare va apărea acum. Faceți clic pe butonul <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` în mijloc, în partea de jos, pentru a începe sincronizarea cu dispozitivul VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/ru/docs/data-link/alma-pro/synchronisation.md
+++ b/content/ru/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ aliases: /vc/sync/ru
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Внимание</span><br>
-        Чтобы начать синхронизацию устройства VitalControl, вы должны быть авторизованы на машине в роли пользователя <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. В противном случае кнопка <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> в <a href="#synchronise-vc-ap" >меню синхронизации</a> будет недоступна.
+        Чтобы начать синхронизацию устройства VitalControl, вы должны быть авторизованы на машине в роли пользователя <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. В противном случае кнопка <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> в <a href="#figure3_synchronize_vitalcontrol_alma_pro">меню синхронизации</a> будет недоступна.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ aliases: /vc/sync/ru
 
 1. Теперь появится экран синхронизации. Нажмите на кнопку <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="цифра 3 в круге" title="цифра 3" /> `{{<T "Synchronize" >}}` в середине внизу, чтобы начать синхронизацию с устройством VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/sl/docs/data-link/alma-pro/synchronisation.md
+++ b/content/sl/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ Za izvedbo sinhronizacije med avtomatskim hranilnikom Alma Pro in napravo VitalC
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Pozor</span><br>
-        Da bi začeli sinhronizacijo naprave VitalControl, morate biti prijavljeni na napravo v uporabniški vlogi <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. V nasprotnem primeru je gumb <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> v <a href="#synchronise-vc-ap" >meniju za sinhronizacijo</a> onemogočen.
+        Da bi začeli sinhronizacijo naprave VitalControl, morate biti prijavljeni na napravo v uporabniški vlogi <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. V nasprotnem primeru je gumb <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> v <a href="#figure3_synchronize_vitalcontrol_alma_pro">meniju za sinhronizacijo</a> onemogočen.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ Za izvedbo sinhronizacije med avtomatskim hranilnikom Alma Pro in napravo VitalC
 
 1. Zdaj se bo prikazal zaslon za sinhronizacijo. Kliknite na gumb <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="številka 3 v krogu" title="številka 3" /> `{{<T "Synchronize" >}}` na sredini spodaj, da začnete sinhronizacijo z napravo VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/sv/docs/data-link/alma-pro/synchronisation.md
+++ b/content/sv/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ För att utföra synkronisering mellan Alma Pro automatisk matare och VitalContr
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Uppmärksamhet</span><br>
-        För att starta synkroniseringen av VitalControl-enheten måste du vara inloggad på maskinen i användarrollen <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Annars är knappen <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> i <a href="#synchronise-vc-ap" >Synkroniseringsmenyn</a> inaktiverad.
+        För att starta synkroniseringen av VitalControl-enheten måste du vara inloggad på maskinen i användarrollen <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. Annars är knappen <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> i <a href="#figure3_synchronize_vitalcontrol_alma_pro">Synkroniseringsmenyn</a> inaktiverad.
     </div>
 </div>
 
@@ -70,7 +70,7 @@ För att utföra synkronisering mellan Alma Pro automatisk matare och VitalContr
 
 1. Synkroniseringsskärmen visas nu. Klicka på knappen <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="cirkulerad siffra 3" title="siffra 3" /> `{{<T "Synchronize" >}}` i mitten längst ner för att starta synkronisering med VitalControl-enheten.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/tr/docs/data-link/alma-pro/synchronisation.md
+++ b/content/tr/docs/data-link/alma-pro/synchronisation.md
@@ -42,7 +42,7 @@ Alma Pro otomatik yemlik ve VitalControl cihazı arasında senkronizasyon gerçe
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Dikkat</span><br>
-        VitalControl cihazının senkronizasyonunu başlatmak için, makineye <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span> kullanıcı rolüyle giriş yapmış olmanız gerekir. Aksi takdirde, <a href="#synchronise-vc-ap" >Senkronizasyon menüsünde</a> <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> düğmesi devre dışı kalır.
+        VitalControl cihazının senkronizasyonunu başlatmak için, makineye <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span> kullanıcı rolüyle giriş yapmış olmanız gerekir. Aksi takdirde, <a href="#figure3_synchronize_vitalcontrol_alma_pro">Senkronizasyon menüsünde</a> <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> düğmesi devre dışı kalır.
     </div>
 </div>
 
@@ -62,7 +62,7 @@ Alma Pro otomatik yemlik ve VitalControl cihazı arasında senkronizasyon gerçe
 
 1. Şimdi senkronizasyon ekranı görünecektir. VitalControl cihazı ile senkronizasyonu başlatmak için altta ortada bulunan <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` düğmesine tıklayın.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/uk/docs/data-link/alma-pro/synchronisation.md
+++ b/content/uk/docs/data-link/alma-pro/synchronisation.md
@@ -51,7 +51,7 @@ aliases: /vc/sync/uk
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">Увага</span><br>
-        Щоб розпочати синхронізацію пристрою VitalControl, ви повинні бути увійшли в систему в ролі користувача <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. В іншому випадку кнопка <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> у <a href="#synchronise-vc-ap" >меню Синхронізації</a> буде недоступна.
+        Щоб розпочати синхронізацію пристрою VitalControl, ви повинні бути увійшли в систему в ролі користувача <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span>. В іншому випадку кнопка <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> у <a href="#figure3_synchronize_vitalcontrol_alma_pro">меню Синхронізації</a> буде недоступна.
     </div>
 </div>
 
@@ -72,7 +72,7 @@ aliases: /vc/sync/uk
 
 1. Тепер з'явиться екран синхронізації. Натисніть на кнопку <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="цифра 3 в колі" title="цифра 3" /> `{{<T "Synchronize" >}}` посередині внизу, щоб розпочати синхронізацію з пристроєм VitalControl.
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/content/zh/docs/data-link/alma-pro/synchronisation.md
+++ b/content/zh/docs/data-link/alma-pro/synchronisation.md
@@ -50,7 +50,7 @@ aliases: /vc/sync/zh
     </svg>
     <div>
         <span class="text-primary fs-3 fw-semibold">注意</span><br>
-        要開始同步 VitalControl 設備，您必須以使用者角色 <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span> 登錄到機器。否則，<a href="#synchronise-vc-ap" >同步選單</a>中的 <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> 按鈕將被禁用。
+        要開始同步 VitalControl 設備，您必須以使用者角色 <span style="font-family: monospace; font-size: 90%;">{{<T "SiteManager" >}}</span> 登錄到機器。否則，<a href="#figure3_synchronize_vitalcontrol_alma_pro">同步選單</a>中的 <span style="font-family: monospace; font-size: 90%;">{{<T "Synchronize" >}}</span> 按鈕將被禁用。
     </div>
 </div>
 
@@ -70,7 +70,7 @@ aliases: /vc/sync/zh
 
 1. 現在將顯示同步畫面。點擊底部中間的按鈕 <img src="/digits/3_negative_circled.svg" id="StartSynchronisation_Digit_3" width="25" align="middle" alt="circled number 3" title="number 3" /> `{{<T "Synchronize" >}}` 以開始與 VitalControl 裝置的同步。
 
-<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;">
+<figure class="figure" style="margin-top: 5px; border: 2px solid #dee2e6; border-radius: 16px; overflow: hidden; margin-bottom: 0;" id="figure3_synchronize_vitalcontrol_alma_pro">
 <div style="padding: 12px;">
     <img
         src="../images/synchronise-vitalcontrol-alma-pro.png"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "See file 'AGB_URBAN_DE.rtf'",
       "devDependencies": {
         "autoprefixer": "^10.4.21",
-        "hugo-extended": "0.148.2",
+        "hugo-extended": "0.149.0",
         "postcss-cli": "^11.0.1"
       }
     },
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.148.2",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.148.2.tgz",
-      "integrity": "sha512-Mruej7lSoTcMI3ZhVmimC+cOhRh5jkh+aT5vnbDZpNHm9z0mlQJAYtXWtZ4OYFEg0dngi70sf1Cfgn4q8H2VnQ==",
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.149.0.tgz",
+      "integrity": "sha512-NSCKH9C6SCk4E4LpRELqcyDO+fiGdut+tia8NJy6p180ZOSYWIlGeb/jtvXx0z0inAIutYKd90VNCxT76ifCLw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2912,9 +2912,9 @@
       }
     },
     "hugo-extended": {
-      "version": "0.148.2",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.148.2.tgz",
-      "integrity": "sha512-Mruej7lSoTcMI3ZhVmimC+cOhRh5jkh+aT5vnbDZpNHm9z0mlQJAYtXWtZ4OYFEg0dngi70sf1Cfgn4q8H2VnQ==",
+      "version": "0.149.0",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.149.0.tgz",
+      "integrity": "sha512-NSCKH9C6SCk4E4LpRELqcyDO+fiGdut+tia8NJy6p180ZOSYWIlGeb/jtvXx0z0inAIutYKd90VNCxT76ifCLw==",
       "dev": true,
       "requires": {
         "careful-downloader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "hugo-extended": "0.148.2",
+    "hugo-extended": "0.149.0",
     "postcss-cli": "^11.0.1"
   }
 }


### PR DESCRIPTION
Der broken Link wurde in allen Sprachen behoben. href zeigt nun auf die entsprechende Menüabbildung.